### PR TITLE
More improvements to charts generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ optional arguments:
                         set vertical line, format: yyyymmddHHMISS
   --x-datetime-format X_DATETIME_FORMAT
                         set datetime format for devices x-axis
+  --title TITLE         set title for graph
   --without-cpu         don't plot CPU data
   --cpu-only            plot only CPU data
 ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ my-iostat.png: PNG image data, 1800 x 1400, 8-bit/color RGBA, non-interlaced
   * filter `io_rqm` and `iops` with `--subplots`
 
 ```bash
-(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png plot --subplots io_rqm iops
+(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png \
+  plot --subplots io_rqm iops
 ```
 
 * show any range of date time
@@ -165,14 +166,37 @@ my-iostat.png: PNG image data, 1800 x 1400, 8-bit/color RGBA, non-interlaced
   * filter until 2018-06-13 14:11:30 with `--until`
 
 ```bash
-(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png --since 20180613141100 --until 20180613141130 plot --subplots await svctm
+(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png \
+  --since 20180613141100 --until 20180613141130 plot --subplots await svctm
 ```
 
 * show vertical lines into graph
   * 2018-06-13 14:11:10 and 2018-06-13 14:11:20 with `--vlines`
 
 ```bash
-(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png --since 20180613141100 --until 20180613141130 plot --subplots await svctm --vlines 20180613141110 20180613141120
+(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png \
+  --since 20180613141100 --until 20180613141130 plot --subplots await svctm --vlines 20180613141110 20180613141120
+```
+
+* show only CPU-related data
+
+```bash
+(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png \
+  plot --cpu-only
+```
+
+* show only one subplot, without CPU information
+
+```bash
+(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png \
+  plot --subplots await --without-cpu
+```
+
+* generate graph with custom title
+
+```bash
+(venv) $ iostat-cli --data tests/fixtures/sample_iostat.output --disk sda --fig-output my-iostat.png \
+  plot --title 'my custom test'
 ```
 
 #### csv

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ optional arguments:
                         set subplots to show
   --vlines VLINES [VLINES ...]
                         set vertical line, format: yyyymmddHHMISS
+  --x-datetime-format X_DATETIME_FORMAT
+                        set datetime format for devices x-axis
+  --without-cpu         don't plot CPU data
+  --cpu-only            plot only CPU data
 ```
 
 #### monitor

--- a/iostat/main.py
+++ b/iostat/main.py
@@ -101,7 +101,15 @@ def parse_plot_argument(subparsers):
         '--x-datetime-format', action='store', dest='x_datetime_format',
         help='set datetime format for devices x-axis'
     )
-
+    group = plot_parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '--without-cpu', dest='with_cpu', action='store_false',
+        help='don\'t plot CPU data'
+    )
+    group.add_argument(
+        '--cpu-only', dest='cpu_only', action='store_true',
+        help='plot only CPU data'
+    )
 
 def parse_argument():
     parser = argparse.ArgumentParser()
@@ -113,6 +121,8 @@ def parse_argument():
         output='iostat.log',
         # filter options
         disks=[],
+        with_cpu=True,
+        cpu_only=False,
         since=None,
         until=None,
         subcommand=SUB_COMMAND_MONITOR,

--- a/iostat/main.py
+++ b/iostat/main.py
@@ -101,6 +101,10 @@ def parse_plot_argument(subparsers):
         '--x-datetime-format', action='store', dest='x_datetime_format',
         help='set datetime format for devices x-axis'
     )
+    plot_parser.add_argument(
+        '--title', action='store', dest='title', default='iostat output',
+        help='set title for graph'
+    )
     group = plot_parser.add_mutually_exclusive_group()
     group.add_argument(
         '--without-cpu', dest='with_cpu', action='store_false',

--- a/iostat/plotter.py
+++ b/iostat/plotter.py
@@ -28,16 +28,25 @@ class Plotter(Renderer):
         self.fig = plt.figure(figsize=figsize)
         self.fig.suptitle('iostat output')
 
+        if self.args.cpu_only:
+            self.args.subplots = []
+        
+        if self.args.with_cpu:
+            add_rows=1
+        else:
+            add_rows=0
+            
         row_length = math.ceil(len(args.subplots) / 2.0)
-        gs = gridspec.GridSpec(row_length + 1, 2, wspace=0.4)
+        gs = gridspec.GridSpec(row_length + add_rows, 2, wspace=0.4)
 
-        self.cpu = self.fig.add_subplot(gs[0, :])
-        self.cpu.set_title('cpu average')
-        self.cpu.set_ylim(0, 100)
-        self.cpu.set_ylabel('percent')
+        if args.with_cpu:
+            self.cpu = self.fig.add_subplot(gs[0, :])
+            self.cpu.set_title('cpu average')
+            self.cpu.set_ylim(0, 100)
+            self.cpu.set_ylabel('percent')
 
         self.subplots = {}
-        gs_range = [(i, j) for j in (0, 1) for i in range(1, row_length + 1)]
+        gs_range = [(i, j) for j in (0, 1) for i in range(add_rows, row_length + add_rows)]
         for i, (row, column) in enumerate(gs_range):
             try:
                 name = args.subplots[i]
@@ -162,9 +171,12 @@ class Plotter(Renderer):
 
     def plot(self):
         datetime_data = [i['date'] for i in self.stats]
-        self.plot_cpu(datetime_data)
-        self.plot_device(datetime_data)
-        plt.subplots_adjust(hspace=0.5)
+        if not self.args.cpu_only:
+            self.plot_device(datetime_data)
+        if self.args.with_cpu:
+            self.plot_cpu(datetime_data)
+        if not self.args.cpu_only and self.args.with_cpu:
+            plt.subplots_adjust(hspace=0.4)
 
     def show(self):
         plt.show(block=True)

--- a/iostat/plotter.py
+++ b/iostat/plotter.py
@@ -19,6 +19,7 @@ class Plotter(Renderer):
     def __init__(self, args, stats):
         self.args = args
         self.stats = stats
+        self.subplot_borderaxespad=-1
 
         figsize = args.figsize
         if figsize is None:
@@ -42,7 +43,11 @@ class Plotter(Renderer):
                 name = args.subplots[i]
             except IndexError:
                 break
-            subplot = self.fig.add_subplot(gs[row, column])
+            if len(args.subplots) == 1:
+                subplot = self.fig.add_subplot(gs[row, :])
+                self.subplot_borderaxespad=-3
+            else:
+                subplot = self.fig.add_subplot(gs[row, column])
             self.set_device_subplot_params(name, subplot)
             if self.args.x_datetime_format is not None:
                 x_format = mdates.DateFormatter(self.args.x_datetime_format)
@@ -153,7 +158,7 @@ class Plotter(Renderer):
                 self.subplots[name].axvline(
                     vline, linestyle=':', linewidth=3, color='purple',
                 )
-            self.subplots[name].legend(bbox_to_anchor=(1.04,0.5), loc="center left", borderaxespad=-1)
+            self.subplots[name].legend(bbox_to_anchor=(1.04,0.5), loc="center left", borderaxespad=self.subplot_borderaxespad)
 
     def plot(self):
         datetime_data = [i['date'] for i in self.stats]

--- a/iostat/plotter.py
+++ b/iostat/plotter.py
@@ -26,7 +26,7 @@ class Plotter(Renderer):
             figsize = (18, 14)
 
         self.fig = plt.figure(figsize=figsize)
-        self.fig.suptitle('iostat output')
+        self.fig.suptitle(self.args.title)
 
         if self.args.cpu_only:
             self.args.subplots = []


### PR DESCRIPTION
There are several improvements to plots generation to make it's easier to analyze data:

- Current implementation uses only half of the row even if single subplot was specified
in the command line... First commit of this PR allows to use the whole row for graph, making it's easier to analyze the data
- option `--without-cpu` was added to allow generation of only subplots
- option `--cpu-only` was added to allow generation of graph for CPU only
- option `--title` was added to specify the chart's title