### PR TITLE
Use %H for output generated with iostat -t

### DIFF
--- a/iostat/utils.py
+++ b/iostat/utils.py
@@ -21,8 +21,8 @@ def parse_datetime(s, fmt='%Y%m%d%H%M%S'):
     >>> parse_datetime('06/13/2018 02:10:50 PM', fmt='%m/%d/%Y %I:%M:%S %p')
     datetime.datetime(2018, 6, 13, 14, 10, 50)
 
-    >>> parse_datetime('09/26/21 03:35:19', fmt='%m/%d/%y %I:%M:%S')
-    datetime.datetime(2021, 9, 26, 3, 35, 19)
+    >>> parse_datetime('09/26/21 13:35:19', fmt='%m/%d/%y %H:%M:%S')
+    datetime.datetime(2021, 9, 26, 13, 35, 19)
     """
     return datetime.strptime(s, fmt)
 
@@ -32,7 +32,7 @@ IOSTAT_DATE_EN = re.compile(r"""
 (?P<date>^\d{2}/\d{2}/\d{4}\s*\d{2}:\d{2}:\d{2}\s*(AM|PM))
 """, re.VERBOSE)
 
-IOSTAT_DATE_FORMAT_JA = '%m/%d/%y %I:%M:%S'
+IOSTAT_DATE_FORMAT_JA = '%m/%d/%y %H:%M:%S'
 IOSTAT_DATE_JA = re.compile(r"""
 (?P<date>^\d{2}/\d{2}/\d{2}\s*\d{2}:\d{2}:\d{2})
 """, re.VERBOSE)
@@ -42,8 +42,8 @@ def get_iostat_date_format(s):
     """
     >>> get_iostat_date_format('06/13/2018 02:10:50 PM')
     '%m/%d/%Y %I:%M:%S %p'
-    >>> get_iostat_date_format('09/26/21 03:35:19')
-    '%m/%d/%y %I:%M:%S'
+    >>> get_iostat_date_format('09/26/21 13:35:19')
+    '%m/%d/%y %H:%M:%S'
     >>> get_iostat_date_format('09/26/2021 03:35:19') is None
     True
     """


### PR DESCRIPTION
LANG=en_US.UTF-8 iostat -t generates timestamps which use 24-hour time This does not match the IOSTAT_DATE_FORMAT_JA, which uses %I, 12-hour value and would require a %p for AM/PM; in any case, the JA format is not generated by iostat.  Fix the examples and switch %I -> %H

Fixes: #5